### PR TITLE
Hack a pip install for python-qpid-proton

### DIFF
--- a/pyngus/__init__.py
+++ b/pyngus/__init__.py
@@ -23,4 +23,4 @@ from pyngus.link import SenderLink, SenderEventHandler
 from pyngus.sockets import read_socket_input
 from pyngus.sockets import write_socket_output
 
-VERSION = (0, 0, 0)  # major, minor, fix
+VERSION = (1, 3, 0)  # major, minor, fix

--- a/setup.py
+++ b/setup.py
@@ -16,10 +16,27 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-#
+
 from setuptools import setup
 
-_VERSION = "0.0.0"   # NOTE: update __init__.py too!
+_VERSION = "1.3.0"   # NOTE: update __init__.py too!
+
+try:
+    # NOTE(flaper87): Hold your breath, don't kill any kittens
+    # (or do it, that's fine) but certainly don't chase the author
+    # of this patch. The reason we're doing this is because the proposed
+    # patch that will (hopefully) land in master[0] targets the 0.10 release
+    # of the library but the current stable version is 0.10. As soon as
+    # the patch lands and 0.10 is out, this will be removed and we'll
+    # all be back to our happy and ideal world where kgiusti has a blue Tesla.
+    # [0] https://issues.apache.org/jira/browse/PROTON-885
+    _qpid_proton = "-egit+https://github.com/FlaPer87/qpid-proton.git@0.9.x#egg=python-qpid-proton&subdirectory=proton-c/bindings/python"
+
+    import subprocess
+    subprocess.Popen(['pip', 'install', _qpid_proton]).wait()
+except Exception:
+    pass
+
 
 setup(name="pyngus",
       version=_VERSION,

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,3 @@
 pep8>=1.4.5,<=1.5.7
 pyflakes>=0.7.3
 flake8>=2.1.0
-
--e git+https://github.com/FlaPer87/qpid-proton.git@0.9.x#egg=python-qpid-proton&subdirectory=proton-c/bindings/python


### PR DESCRIPTION
Make sure the required python-qpid-proton version is installed. This is
temporary until the proposed upstream patch lands and qpid-proton 0.10
is released. It's ugly, yes but bare with us here while we try to clean
this up.