### PR TITLE
Remove the hack and rely just on pypi

### DIFF
--- a/pyngus/__init__.py
+++ b/pyngus/__init__.py
@@ -23,4 +23,4 @@ from pyngus.link import SenderLink, SenderEventHandler
 from pyngus.sockets import read_socket_input
 from pyngus.sockets import write_socket_output
 
-VERSION = (1, 3, 0)  # major, minor, fix
+VERSION = (1, 3, 1)  # major, minor, fix

--- a/setup.py
+++ b/setup.py
@@ -19,23 +19,7 @@
 
 from setuptools import setup
 
-_VERSION = "1.3.0"   # NOTE: update __init__.py too!
-
-try:
-    # NOTE(flaper87): Hold your breath, don't kill any kittens
-    # (or do it, that's fine) but certainly don't chase the author
-    # of this patch. The reason we're doing this is because the proposed
-    # patch that will (hopefully) land in master[0] targets the 0.10 release
-    # of the library but the current stable version is 0.10. As soon as
-    # the patch lands and 0.10 is out, this will be removed and we'll
-    # all be back to our happy and ideal world where kgiusti has a blue Tesla.
-    # [0] https://issues.apache.org/jira/browse/PROTON-885
-    _qpid_proton = "-egit+https://github.com/FlaPer87/qpid-proton.git@0.9.x#egg=python-qpid-proton&subdirectory=proton-c/bindings/python"
-
-    import subprocess
-    subprocess.Popen(['pip', 'install', _qpid_proton]).wait()
-except Exception:
-    pass
+_VERSION = "1.3.1"   # NOTE: update __init__.py too!
 
 
 setup(name="pyngus",


### PR DESCRIPTION
The version 0.9 has been finally released. It can now be consumed by
pyngus directly.