### PR TITLE
Add empty process_(remote|local)_state methods

### DIFF
--- a/pyngus/endpoint.py
+++ b/pyngus/endpoint.py
@@ -157,6 +157,12 @@ class Endpoint(object):
             except IndexError:
                 LOG.debug("Endpoint %s: ignoring unexpected local event",
                           self._name)
+    else:
+        def _process_remote_state(self):
+            pass
+
+        def _process_local_state(self):
+            pass
 
     @property
     def _endpoint_state(self):

--- a/pyngus/link.py
+++ b/pyngus/link.py
@@ -193,7 +193,7 @@ class _Link(Endpoint):
         # if link not already closed:
         if self._endpoint_state & proton.Endpoint.REMOTE_ACTIVE:
             # simulate close received
-            self.process_remote_state()
+            self._process_remote_state()
         elif self._endpoint_state & proton.Endpoint.REMOTE_UNINIT:
             # locally created link, will never come up
             self._failed = True


### PR DESCRIPTION
I think we should change the way these things are handled but for now, lets fix the missing method