### PR TITLE
Port to new SASL interface in proton 0.10

### DIFF
--- a/docs/User-Guide.md
+++ b/docs/User-Guide.md
@@ -228,11 +228,27 @@ case of TCP).  Parameters:
      heartbeat generation by the peer, if supported.
    * "x-trace-protocol" - boolean, if True, enable debug dumps of the
      AMQP wire traffic.
+   * "x-server" - boolean, set this to True to configure the
+     connection as a server side connection.  This should be set True
+     if the connection was remotely initiated (e.g. accept on a
+     listening socket).  If the connection was locally initiated
+     (e.g. by calling connect()), then this value should be set to
+     False.  This setting is used by authentication and encryption to
+     configure the connection's role.  The default value is False for
+     client mode.
+   * "x-username" - string, the client's username to use when
+     authenticating with a server.
+   * "x-password" - string, the client's password, used for
+     authentication.
+   * "x-require-auth" - boolean, reject remotely-initiated client
+     connections that fail to provide valid credentials for
+     authentication.
+   * "x-sasl-mechs" - string, a space-separated list of mechanisms
+     that are allowed for authentication.  Defaults to "ANONYMOUS"
    * "x-ssl-ca-file" - string, path to a PEM file containing the
      certificates of the trusted Certificate Authorities that will be
      used to check the signature of the peer's certificate.
-   * "x-ssl-server" - boolean, if True, the Connection acts as a SSL
-     server (default False - use Client mode)
+   * "x-ssl-server" - __DEPRECATED__ use x-server instead.
    * "x-ssl-identity" - tuple, contains self-identifying certificate
      information which will be presented to the peer.  The first item
      in the tuple is the path to the certificate file (PEM format).
@@ -259,9 +275,9 @@ case of TCP).  Parameters:
      necessary.  A DNS host name is required to authenticate peer's
      certificate (see x-ssl-verify-mode).
    * "x-ssl-allow-cleartext" - boolean, allows clients to connect
-      without using SSL (eg, plain TCP). Used by a server that will
-      accept clients requesting either trusted or untrusted
-      connections.
+     without using SSL (eg, plain TCP). Used by a server that will
+     accept clients requesting either trusted or untrusted
+     connections.
 
 `Container.name()`
 

--- a/examples/recv.py
+++ b/examples/recv.py
@@ -63,7 +63,11 @@ def main(argv=None):
     # create AMQP Container, Connection, and SenderLink
     #
     container = pyngus.Container(uuid.uuid4().hex)
-    conn_properties = {'hostname': host}
+    conn_properties = {'hostname': host,
+                       'x-server': False,
+                       'x-username': 'guest',
+                       'x-password': 'guest',
+                       'x-sasl-mechs': "ANONYMOUS PLAIN"}
     if opts.trace:
         conn_properties["x-trace-protocol"] = True
     if opts.ca:
@@ -74,8 +78,6 @@ def main(argv=None):
     connection = container.create_connection("receiver",
                                              None,  # no events
                                              conn_properties)
-    connection.pn_sasl.mechanisms("ANONYMOUS")
-    connection.pn_sasl.client()
     connection.open()
 
     class ReceiveCallback(pyngus.ReceiverEventHandler):

--- a/examples/rpc-client.py
+++ b/examples/rpc-client.py
@@ -68,8 +68,6 @@ class MyConnection(pyngus.ConnectionEventHandler):
                                                            self,
                                                            self.properties)
         self.connection.user_context = self
-        self.connection.sasl.mechanisms("ANONYMOUS")
-        self.connection.sasl.client()
         self.connection.open()
 
     def process(self):
@@ -152,9 +150,6 @@ class MyConnection(pyngus.ConnectionEventHandler):
         # call accept_sender to accept new link,
         # reject_sender to reject it.
         assert False, "Not expected"
-
-    def sasl_step(self, connection, pn_sasl):
-        LOG.debug("sasl_step")
 
     def sasl_done(self, connection, pn_sasl, result):
         LOG.debug("SASL done, result=%s", str(result))

--- a/examples/rpc-server.py
+++ b/examples/rpc-server.py
@@ -69,8 +69,6 @@ class SocketConnection(pyngus.ConnectionEventHandler):
         self.connection = container.create_connection(name, self,
                                                       conn_properties)
         self.connection.user_context = self
-        self.connection.sasl.mechanisms("ANONYMOUS")
-        self.connection.sasl.server()
         self.connection.open()
         self.done = False
 
@@ -396,7 +394,7 @@ def main(argv=None):
                 client_socket, client_address = my_socket.accept()
                 name = uuid.uuid4().hex
                 assert name not in socket_connections
-                conn_properties = {}
+                conn_properties = {'x-server': True}
                 if opts.idle_timeout:
                     conn_properties["idle-time-out"] = opts.idle_timeout
                 if opts.trace:

--- a/examples/send.py
+++ b/examples/send.py
@@ -68,7 +68,9 @@ def main(argv=None):
     # create AMQP Container, Connection, and SenderLink
     #
     container = pyngus.Container(uuid.uuid4().hex)
-    conn_properties = {'hostname': host}
+    conn_properties = {'hostname': host,
+                       'x-server': False,
+                       'x-sasl-mechs': "ANONYMOUS PLAIN"}
     if opts.trace:
         conn_properties["x-trace-protocol"] = True
     if opts.ca:
@@ -79,8 +81,6 @@ def main(argv=None):
     connection = container.create_connection("sender",
                                              None,  # no events
                                              conn_properties)
-    connection.pn_sasl.mechanisms("ANONYMOUS")
-    connection.pn_sasl.client()
     connection.open()
 
     source_address = opts.source_addr or uuid.uuid4().hex

--- a/examples/server.py
+++ b/examples/server.py
@@ -46,8 +46,6 @@ class SocketConnection(pyngus.ConnectionEventHandler):
                                                       self,  # handler
                                                       properties)
         self.connection.user_context = self
-        self.connection.pn_sasl.mechanisms("ANONYMOUS")
-        self.connection.pn_sasl.server()
         self.connection.open()
         self.closed = False
 
@@ -109,8 +107,8 @@ class SocketConnection(pyngus.ConnectionEventHandler):
 
     def connection_failed(self, connection, error):
         LOG.error("Connection: failed! error=%s", str(error))
-        # No special recovery - just close it:
-        self.connection.close()
+        # No special recovery - just simulate close completed:
+        self.connection_closed(connection)
 
     def sender_requested(self, connection, link_handle,
                          name, requested_source, properties):
@@ -302,7 +300,9 @@ def main(argv=None):
                 client_socket, client_address = my_socket.accept()
                 # name = uuid.uuid4().hex
                 name = str(client_address)
-                conn_properties = {}
+                conn_properties = {'x-server': True,
+                                   'x-require-auth': False,
+                                   'x-sasl-mechs': "ANONYMOUS"}
                 if opts.idle_timeout:
                     conn_properties["idle-time-out"] = opts.idle_timeout
                 if opts.trace:

--- a/pyngus/__init__.py
+++ b/pyngus/__init__.py
@@ -23,4 +23,4 @@ from pyngus.link import SenderLink, SenderEventHandler
 from pyngus.sockets import read_socket_input
 from pyngus.sockets import write_socket_output
 
-VERSION = (1, 4, 0)  # major, minor, fix
+VERSION = (2, 0, 0)  # major, minor, fix


### PR DESCRIPTION
Proton 0.10 completely changes the interface to the proton.SASL class.
This patch adds new connection properties that will compensate for the
changes to the SASL configuration interface.  However, since pyngus
never wrapped proton's SASL class, applications will have to be
updated to use the new connection API to take advantage of this
abstraction.

Bumping version to 2.0.0